### PR TITLE
Support Laravel 9.33 and higher

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         php: [ 8.1, 8.2 ]
-        laravel: [ 10 ]
+        laravel: [ 9, 10 ]
         stability: [ 'prefer-lowest', 'prefer-stable' ]
 
     name:  PHP ${{ matrix.php }} L${{ matrix.laravel }} w/ ${{ matrix.stability }}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Laravel-based library to easily build [Plain UI component](https://docs.plain.
 ## Requirements
 
 - PHP 8.1 or higher
-- Laravel 10.0 or higher
+- Laravel 9.33 or higher
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,8 @@
     },
     "require": {
         "php": "~8.1.0|~8.2.0",
-        "ext-json": "*",
-        "illuminate/http": "^10.10",
-        "illuminate/support": "^10.10"
+        "illuminate/http": "^9.33|^10.0",
+        "illuminate/support": "^9.33|^10.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",


### PR DESCRIPTION
There's no reason we couldn't support this, as everything that we're using has been available within Laravel for a long time.